### PR TITLE
Serialize TelemetryItem before sending it to persistence.

### DIFF
--- a/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/ChannelQueueTest.java
+++ b/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/ChannelQueueTest.java
@@ -46,8 +46,8 @@ public class ChannelQueueTest extends InstrumentationTestCase {
         when(mockConfig.getMaxBatchCount()).thenReturn(3);
 
         // Test
-        sut.enqueue(new Envelope());
-        sut.enqueue(new Envelope());
+        sut.enqueue(new String());
+        sut.enqueue(new String());
 
         // Verify
         Assert.assertEquals(2, sut.list.size());
@@ -59,17 +59,17 @@ public class ChannelQueueTest extends InstrumentationTestCase {
         when(mockConfig.getMaxBatchCount()).thenReturn(3);
 
         // Test
-        sut.enqueue(new Envelope());
-        sut.enqueue(new Envelope());
+        sut.enqueue(new String());
+        sut.enqueue(new String());
 
         // Verify
         Assert.assertEquals(2, sut.list.size());
-        verify(mockPersistence,never()).persist(any(IJsonSerializable[].class), anyBoolean());
+        verify(mockPersistence,never()).persist(any(String[].class), anyBoolean());
 
-        sut.enqueue(new Envelope());
+        sut.enqueue(new String());
 
         Assert.assertEquals(0, sut.list.size());
-        verify(mockPersistence,times(1)).persist(any(IJsonSerializable[].class), anyBoolean());
+        verify(mockPersistence,times(1)).persist(any(String[].class), anyBoolean());
     }
 
     public void testQueueFlushedAfterBatchIntervalReached() {
@@ -78,12 +78,12 @@ public class ChannelQueueTest extends InstrumentationTestCase {
         when(mockConfig.getMaxBatchCount()).thenReturn(3);
 
         // Test
-        sut.enqueue(new Envelope());
+        sut.enqueue(new String());
 
         // Verify
         Assert.assertEquals(1, sut.list.size());
-        verify(mockPersistence,never()).persist(any(IJsonSerializable[].class), anyBoolean());
-        verify(mockPersistence,after(250).times(1)).persist(any(IJsonSerializable[].class), anyBoolean());
+        verify(mockPersistence,never()).persist(any(String[].class), anyBoolean());
+        verify(mockPersistence,after(250).times(1)).persist(any(String[].class), anyBoolean());
         Assert.assertEquals(0, sut.list.size());
     }
 
@@ -92,16 +92,16 @@ public class ChannelQueueTest extends InstrumentationTestCase {
         when(mockConfig.getMaxBatchIntervalMs()).thenReturn(200);
         when(mockConfig.getMaxBatchCount()).thenReturn(3);
 
-        sut.enqueue(new Envelope());
+        sut.enqueue(new String());
         Assert.assertEquals(1, sut.list.size());
-        verify(mockPersistence,never()).persist(any(IJsonSerializable[].class), anyBoolean());
+        verify(mockPersistence,never()).persist(any(String[].class), anyBoolean());
 
         // Test
         sut.flush();
 
         // Verify
         Assert.assertEquals(0, sut.list.size());
-        verify(mockPersistence,times(1)).persist(any(IJsonSerializable[].class), anyBoolean());
+        verify(mockPersistence,times(1)).persist(any(String[].class), anyBoolean());
     }
 
 

--- a/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/ChannelTest.java
+++ b/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/ChannelTest.java
@@ -34,13 +34,17 @@ public class ChannelTest extends InstrumentationTestCase {
     public void testEnqueuedItemIsAddedToQueue(){
         // Test
         Envelope testItem1 = new Envelope();
+        testItem1.setDeviceId("Test");
+        String serialized1 = sut.serializeEnvelope(testItem1);
         sut.enqueue(testItem1);
         Envelope testItem2 = new Envelope();
+        testItem2.setDeviceId("Test1");
+        String serialized2 = sut.serializeEnvelope(testItem2);
         sut.enqueue(testItem2);
 
         // Verify
-        verify(mockQueue, times(1)).enqueue(testItem1);
-        verify(mockQueue, times(1)).enqueue(testItem2);
+        verify(mockQueue, times(1)).enqueue(serialized1);
+        verify(mockQueue, times(1)).enqueue(serialized2);
     }
 
     public void testProcessUnhandledExceptionIsPersistedDirectly(){
@@ -49,19 +53,20 @@ public class ChannelTest extends InstrumentationTestCase {
         sut.processUnhandledException(testItem1);
 
         // Verify
-        verify(mockQueue, times(0)).enqueue(testItem1);
-        verify(mockPersistence, times(1)).persist(any(IJsonSerializable[].class), eq(true));
+        verify(mockQueue, times(0)).enqueue(new String());
+        verify(mockPersistence, times(1)).persist(any(String[].class), eq(true));
     }
 
     public void testQueueFlushesWhenProcessingCrash(){
         // Setup
         Envelope testItem1 = new Envelope();
+        String serializedString = sut.serializeEnvelope(testItem1);
 
         // Test
         sut.processUnhandledException(testItem1);
 
         // Verify
-        verify(mockQueue, times(0)).enqueue(testItem1);
+        verify(mockQueue, times(0)).enqueue(serializedString);
         verify(mockQueue, times(1)).flush();
     }
 }

--- a/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/PersistenceTest.java
+++ b/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/PersistenceTest.java
@@ -29,7 +29,7 @@ public class PersistenceTest extends AndroidTestCase {
         Persistence persistence = Persistence.getInstance();
 
         String data = "SAVE THIS DATA";
-        persistence.persist(data, false);
+        persistence.writeToDisk(data, false);
         File file = persistence.nextAvailableFile();
         Assert.assertEquals("Data retrieved from file is equal to data saved", data, persistence.load(file));
     }

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/ChannelQueue.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/ChannelQueue.java
@@ -1,6 +1,5 @@
 package com.microsoft.applicationinsights.library;
 
-import com.microsoft.applicationinsights.contracts.shared.IJsonSerializable;
 import com.microsoft.applicationinsights.library.config.IQueueConfig;
 import com.microsoft.applicationinsights.logging.InternalLogging;
 
@@ -37,7 +36,7 @@ class ChannelQueue {
     /**
      * The linked list for this queue
      */
-    protected final List<IJsonSerializable> list;
+    protected final List<String> list;
 
     /**
      * If true the app is crashing and data should be persisted instead of sent
@@ -58,7 +57,7 @@ class ChannelQueue {
      * Prevent external instantiation
      */
     protected ChannelQueue(IQueueConfig config) {
-        this.list = new LinkedList<IJsonSerializable>();
+        this.list = new LinkedList<String>();
         this.timer = new Timer("Application Insights Sender Queue", true);
         this.config = config;
         this.isCrashing = false;
@@ -68,19 +67,19 @@ class ChannelQueue {
     /**
      * Adds an item to the sender queue
      *
-     * @param item a telemetry item to enqueue
+     * @param serializedItem a serialized telemetry item to enqueue
      * @return true if the item was successfully added to the queue
      */
-    protected boolean enqueue(IJsonSerializable item) {
+    protected boolean enqueue(String serializedItem) {
         // prevent invalid argument exception
-        if (item == null) {
+        if (serializedItem == null) {
             return false;
         }
 
         boolean success;
         synchronized (this.LOCK) {
             // attempt to add the item to the queue
-            success = this.list.add(item);
+            success = this.list.add(serializedItem);
 
             if (success) {
                 if ((this.list.size() >= this.config.getMaxBatchCount()) || isCrashing) {
@@ -106,10 +105,10 @@ class ChannelQueue {
             this.scheduledPersistenceTask.cancel();
         }
 
-        IJsonSerializable[] data;
+        String[] data;
         synchronized (this.LOCK) {
             if (!list.isEmpty()) {
-                data = new IJsonSerializable[list.size()];
+                data = new String[list.size()];
                 list.toArray(data);
                 list.clear();
 
@@ -132,7 +131,7 @@ class ChannelQueue {
     /**
      * Initiates persisting the content queue.
      */
-    protected void executePersistenceTask(IJsonSerializable[] data){
+    protected void executePersistenceTask(String[] data){
         if (data != null) {
             if (persistence != null) {
                 persistence.persist(data, false);

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/Sender.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/Sender.java
@@ -130,7 +130,6 @@ class Sender {
         String persistedData = this.persistence.load(fileToSend);
         if (!persistedData.isEmpty()) {
             try {
-                InternalLogging.info(TAG, "sending persisted data", persistedData);
                 this.operationsCount.getAndIncrement();
                 this.sendRequestWithPayload(persistedData, fileToSend);
             } catch (IOException e) {
@@ -160,7 +159,7 @@ class Sender {
         connection.setUseCaches(false);
 
         try {
-            InternalLogging.info(TAG, "writing payload", payload);
+            InternalLogging.info(TAG, "Logging payload", payload);
             writer = getWriter(connection);
             writer.write(payload);
             writer.flush();

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/TrackDataOperation.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/TrackDataOperation.java
@@ -3,6 +3,12 @@ package com.microsoft.applicationinsights.library;
 import com.microsoft.applicationinsights.contracts.Envelope;
 import com.microsoft.applicationinsights.contracts.shared.ITelemetry;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 
 class TrackDataOperation implements Runnable {
@@ -28,35 +34,63 @@ class TrackDataOperation implements Runnable {
 
     protected TrackDataOperation(ITelemetry telemetry) {
         this.type = DataType.NONE;
-        this.telemetry = telemetry;
+        try {
+            this.telemetry = (ITelemetry)deepCopy(telemetry);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     protected TrackDataOperation(DataType type) {
-        this.type = type;
+        this.type = type; // no need to copy as enum is pass by value
     }
 
     protected TrackDataOperation(DataType type, String metricName, double metric) {
-        this.type = type;
-        this.name = metricName;
-        this.metric = metric;
+        this.type = type; // no need to copy as enum is pass by value
+        this.metric = metric;  // no need to copy as enum is pass by value
+        try {
+            this.name = (String) deepCopy(metricName);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     protected TrackDataOperation(DataType type,
                                  String name,
                                  Map<String, String> properties,
                                  Map<String, Double> measurements) {
-        this.type = type;
-        this.name = name;
-        this.properties = properties;
-        this.measurements = measurements;
+        this.type = type; // no need to copy as enum is pass by value
+        try {
+            this.name = (String) deepCopy(name);
+            if(properties != null) {
+                this.properties = new HashMap<String, String>(properties);
+            }
+            if(measurements != null) {
+                this.measurements = new HashMap<String, Double>(measurements);
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+
     }
 
     protected TrackDataOperation(DataType type,
                                  Throwable exception,
                                  Map<String, String> properties) {
-        this.type = type;
-        this.exception = exception;
-        this.properties = properties;
+        this.type = type; // no need to copy as enum is pass by value
+        try {
+            this.exception = (Throwable) deepCopy(exception);
+            if(properties != null) {
+                this.properties = new HashMap<String, String>(properties);
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+
     }
 
     @Override
@@ -102,5 +136,13 @@ class TrackDataOperation implements Runnable {
                 channel.enqueue(envelope);
             }
         }
+    }
+
+    private Object deepCopy(Object serializableObject) throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        new ObjectOutputStream(outputStream).writeObject(serializableObject);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+
+        return new ObjectInputStream(inputStream).readObject();
     }
 }

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/config/IQueueConfig.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/config/IQueueConfig.java
@@ -10,13 +10,13 @@ public interface IQueueConfig {
 
     /**
      * Sets the maximum size of a batch in bytes
-     * @param maxBatchCount the batchsize of data that will be queued until we send/persist it
+     * @param maxBatchCount the batchsize of data that will be queued until we send/writeToDisk it
      */
     public void setMaxBatchCount(int maxBatchCount);
 
     /**
      * Gets the maximum interval allowed between calls to batchInvoke
-     * @return the interval until we send/persist queued up data
+     * @return the interval until we send/writeToDisk queued up data
      */
     public int getMaxBatchIntervalMs();
 


### PR DESCRIPTION
I didn't go the "deep copy on main thread" way as:
a) deep copy might create a lot of overhead (and it's generally a bad idea to do a lot of work on the main thread
b) is error prone
c) would have made it necessary to implement serializable & would have required touching our contract files

So I followed @crystk s idea and we now serialize directly after calling enqueue(...) and then have a queue of strings and persist them. Persistence is no longer in charge of serialization but just fileI/O.

Tests pass and from my POV it works, but I wasn't able to verify the bug in the first place.

I'd be great if @chrwend  or @scsouthw have a look and merge
