### PR TITLE
Feature/multiple instances proposal

### DIFF
--- a/app-sample/src/main/java/com/microsoft/applicationinsights/appsample/ItemListActivity.java
+++ b/app-sample/src/main/java/com/microsoft/applicationinsights/appsample/ItemListActivity.java
@@ -5,6 +5,8 @@ import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 
 import com.microsoft.applicationinsights.library.ApplicationInsights;
+import com.microsoft.applicationinsights.library.TelemetryClient;
+import com.microsoft.applicationinsights.library.TelemetryContext;
 import com.microsoft.applicationinsights.library.config.Configuration;
 
 import java.util.HashMap;
@@ -67,6 +69,20 @@ public class ItemListActivity extends FragmentActivity
         properties.put("Hometown", "Karlsruhe");
         ApplicationInsights.setCommonProperties(properties);
         ApplicationInsights.start();
+
+
+        //TODO: proposal by Benny for multiple telemetryclients
+
+        ApplicationInsights.addModule("foobar", "ikey", getApplicationContext(), getApplication());
+        ApplicationInsights.start(); //starts all modules
+        TelemetryClient foobarclient = ApplicationInsights.getTelemetryClient("foobar");
+        foobarclient.trackEvent("myevent");
+        TelemetryContext context = ApplicationInsights.getTelemetryContext("foobar");
+        context.setAccountId("foobarUser");
+
+        //TODO Proposal von Chris
+        TelemetryManager tm = new TelemetryManager(getApplicationContext(), new TelemtryConfig());
+        //we could
     }
 
     /**

--- a/app-sample/src/main/java/com/microsoft/applicationinsights/appsample/ItemListActivity.java
+++ b/app-sample/src/main/java/com/microsoft/applicationinsights/appsample/ItemListActivity.java
@@ -5,7 +5,7 @@ import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 
 import com.microsoft.applicationinsights.library.ApplicationInsights;
-import com.microsoft.applicationinsights.library.config.ApplicationInsightsConfig;
+import com.microsoft.applicationinsights.library.config.Configuration;
 
 import java.util.HashMap;
 
@@ -54,7 +54,7 @@ public class ItemListActivity extends FragmentActivity
         }
         ApplicationInsights.setup(this.getApplicationContext(), getApplication());
 
-        ApplicationInsightsConfig config = ApplicationInsights.getConfig();
+        Configuration config = ApplicationInsights.getConfiguration();
         //config.setSessionIntervalMs(30000);
         //config.setEndpointUrl("https://myserver.com/v2/track");
         config.setMaxBatchCount(45);

--- a/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/SenderTest.java
+++ b/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/SenderTest.java
@@ -1,6 +1,6 @@
 package com.microsoft.applicationinsights.library;
 
-import com.microsoft.applicationinsights.library.config.ApplicationInsightsConfig;
+import com.microsoft.applicationinsights.library.config.Configuration;
 
 import junit.framework.Assert;
 import junit.framework.TestCase;
@@ -13,7 +13,7 @@ public class SenderTest extends TestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        ApplicationInsightsConfig config = new ApplicationInsightsConfig();
+        Configuration config = new Configuration();
         this.sut = new Sender(config);
     }
 
@@ -24,7 +24,7 @@ public class SenderTest extends TestCase {
 
     public void testCallGetInstanceTwiceReturnsSameObject(){
 
-        Sender.initialize(new ApplicationInsightsConfig());
+        Sender.initialize(new Configuration());
         Sender sender1 = Sender.getInstance();
         Sender sender2 = Sender.getInstance();
 

--- a/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/TelemetryClientTestE2E.java
+++ b/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/TelemetryClientTestE2E.java
@@ -3,7 +3,7 @@ package com.microsoft.applicationinsights.library;
 import android.test.ApplicationTestCase;
 import android.util.Log;
 
-import com.microsoft.applicationinsights.library.config.ApplicationInsightsConfig;
+import com.microsoft.applicationinsights.library.config.Configuration;
 
 import junit.framework.Assert;
 
@@ -26,7 +26,7 @@ public class TelemetryClientTestE2E extends ApplicationTestCase<MockApplication>
         ApplicationInsights.setup(this.getContext(), this.getApplication());
         ApplicationInsights.setDeveloperMode(true);
 
-        ApplicationInsightsConfig config = ApplicationInsights.getConfig();
+        Configuration config = ApplicationInsights.getConfiguration();
         config.setEndpointUrl(config.getEndpointUrl().replace("https", "http"));
         config.setMaxBatchIntervalMs(10);
         config.setMaxBatchCount(batchCount);
@@ -99,7 +99,7 @@ public class TelemetryClientTestE2E extends ApplicationTestCase<MockApplication>
 
     public void validate(int count) {
         try {
-            ApplicationInsightsConfig config = new ApplicationInsightsConfig();
+            Configuration config = new Configuration();
             MockSender sender = new MockSender(count, config);
 
             sender.flush(count);

--- a/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/config/ConfigurationTest.java
+++ b/applicationinsights-android/src/androidTest/java/com/microsoft/applicationinsights/library/config/ConfigurationTest.java
@@ -4,22 +4,22 @@ import android.test.AndroidTestCase;
 
 import com.microsoft.applicationinsights.library.ApplicationInsights;
 
-public class ApplicationInsightsConfigTest extends AndroidTestCase {
+public class ConfigurationTest extends AndroidTestCase {
 
-    private ApplicationInsightsConfig sut;
+    private Configuration sut;
     public void setUp() throws Exception {
         super.setUp();
-        sut = new ApplicationInsightsConfig();
+        sut = new Configuration();
         ApplicationInsights.setDeveloperMode(false);
     }
 
     public void testInitializesCorrectly() throws Exception {
-        assertEquals(ApplicationInsightsConfig.DEFAULT_MAX_BATCH_COUNT, sut.getMaxBatchCount());
-        assertEquals(ApplicationInsightsConfig.DEFAULT_MAX_BATCH_INTERVAL_MS, sut.getMaxBatchIntervalMs());
-        assertEquals(ApplicationInsightsConfig.DEFAULT_ENDPOINT_URL, sut.getEndpointUrl());
-        assertEquals(ApplicationInsightsConfig.DEFAULT_SENDER_READ_TIMEOUT, sut.getSenderReadTimeout());
-        assertEquals(ApplicationInsightsConfig.DEFAULT_SENDER_CONNECT_TIMEOUT, sut.getSenderConnectTimeout());
-        assertEquals(ApplicationInsightsConfig.DEFAULT_SESSION_INTERVAL, sut.getSessionIntervalMs());
+        assertEquals(Configuration.DEFAULT_MAX_BATCH_COUNT, sut.getMaxBatchCount());
+        assertEquals(Configuration.DEFAULT_MAX_BATCH_INTERVAL_MS, sut.getMaxBatchIntervalMs());
+        assertEquals(Configuration.DEFAULT_ENDPOINT_URL, sut.getEndpointUrl());
+        assertEquals(Configuration.DEFAULT_SENDER_READ_TIMEOUT, sut.getSenderReadTimeout());
+        assertEquals(Configuration.DEFAULT_SENDER_CONNECT_TIMEOUT, sut.getSenderConnectTimeout());
+        assertEquals(Configuration.DEFAULT_SESSION_INTERVAL, sut.getSessionIntervalMs());
     }
 
     public void testReturnsDebugValuesInDevMode() throws Exception {
@@ -30,8 +30,8 @@ public class ApplicationInsightsConfigTest extends AndroidTestCase {
 
         // if dev mode enabled, actual values should be ignored
         ApplicationInsights.setDeveloperMode(true);
-        assertEquals(ApplicationInsightsConfig.DEBUG_MAX_BATCH_COUNT, sut.getMaxBatchCount());
-        assertEquals(ApplicationInsightsConfig.DEBUG_MAX_BATCH_INTERVAL_MS, sut.getMaxBatchIntervalMs());
+        assertEquals(Configuration.DEBUG_MAX_BATCH_COUNT, sut.getMaxBatchCount());
+        assertEquals(Configuration.DEBUG_MAX_BATCH_INTERVAL_MS, sut.getMaxBatchIntervalMs());
 
         // if dev mode disabled, actual values should be used
         ApplicationInsights.setDeveloperMode(false);

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/ApplicationInsights.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/ApplicationInsights.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import com.microsoft.applicationinsights.contracts.User;
-import com.microsoft.applicationinsights.library.config.ApplicationInsightsConfig;
+import com.microsoft.applicationinsights.library.config.Configuration;
 import com.microsoft.applicationinsights.logging.InternalLogging;
 
 import java.lang.ref.WeakReference;
@@ -32,7 +32,7 @@ public enum ApplicationInsights {
     /**
      * The configuration of the SDK.
      */
-    private ApplicationInsightsConfig config;
+    private Configuration configuration;
 
     /**
      * A flag, which determines if sending telemetry data should be disabled. Default is false.
@@ -113,7 +113,7 @@ public enum ApplicationInsights {
      */
     ApplicationInsights() {
         this.channelType = ChannelType.Default;
-        this.config = new ApplicationInsightsConfig();
+        this.configuration = new Configuration();
     }
 
     /**
@@ -219,7 +219,7 @@ public enum ApplicationInsights {
         EnvelopeFactory.initialize(telemetryContext, this.commonProperties);
 
         Persistence.initialize(context);
-        Sender.initialize(this.config);
+        Sender.initialize(this.configuration);
         ChannelManager.initialize(channelType);
 
         // Initialize Telemetry
@@ -228,13 +228,13 @@ public enum ApplicationInsights {
             application = this.weakApplication.get();
         }
         TelemetryClient.initialize(!this.telemetryDisabled, application);
-        TelemetryClient.startAutoCollection(this.telemetryContext, this.config, !this.autoAppearanceDisabled, !this.autoPageViewsDisabled, !this.autoSessionManagementDisabled);
+        TelemetryClient.startAutoCollection(this.telemetryContext, this.configuration, !this.autoAppearanceDisabled, !this.autoPageViewsDisabled, !this.autoSessionManagementDisabled);
     }
 
     /**
      * Triggers persisting and if applicable sending of queued data
      * note: this will be called
-     * {@link com.microsoft.applicationinsights.library.config.ApplicationInsightsConfig#maxBatchIntervalMs} after
+     * {@link Configuration#maxBatchIntervalMs} after
      * tracking any telemetry so it is not necessary to call this in most cases.
      */
     public static void sendPendingData() {
@@ -486,8 +486,8 @@ public enum ApplicationInsights {
      *
      * @return the instance ApplicationInsights configuration
      */
-    public static ApplicationInsightsConfig getConfig() {
-        return INSTANCE.config;
+    public static Configuration getConfiguration() {
+        return INSTANCE.configuration;
     }
 
     /**

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/ApplicationInsights.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/ApplicationInsights.java
@@ -163,6 +163,8 @@ public enum ApplicationInsights {
     }
 
     public static void addModule(String moduleName, String instrumentationKey, Context context, Application application) {
+        //TODO: in case context and application are null -> use default context/application
+        //TODO: each new module == clone of default module
         initializeModuleForName(moduleName, context, application,  instrumentationKey);
     }
 

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/ChannelManager.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/ChannelManager.java
@@ -35,7 +35,7 @@ public class ChannelManager {
      */
 
     protected ChannelManager(ChannelType channelType) {
-        Channel.initialize(ApplicationInsights.getConfig());
+        Channel.initialize(ApplicationInsights.getConfiguration());
         setChannel(channelType);
     }
 
@@ -115,7 +115,7 @@ public class ChannelManager {
     private IChannel createDefaultChannel() {
         IChannel defaultChannel = Channel.getInstance();
         if(defaultChannel == null) {
-            Channel.initialize(ApplicationInsights.getConfig());
+            Channel.initialize(ApplicationInsights.getConfiguration());
             defaultChannel = Channel.getInstance();
         }
 
@@ -128,7 +128,7 @@ public class ChannelManager {
      */
     private IChannel createTelemetryClientChannel() {
         String iKey = ApplicationInsights.getInstrumentationKey() == null ? "" : ApplicationInsights.getInstrumentationKey();
-        AndroidCll cll = (AndroidCll)AndroidCll.initialize(iKey, ApplicationInsights.INSTANCE.getContext(), ApplicationInsights.getConfig().getEndpointUrl());
+        AndroidCll cll = (AndroidCll)AndroidCll.initialize(iKey, ApplicationInsights.INSTANCE.getContext(), ApplicationInsights.getConfiguration().getEndpointUrl());
         cll.useLagacyCS(true);
         return cll;
     }

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/Module.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/Module.java
@@ -1,0 +1,281 @@
+package com.microsoft.applicationinsights.library;
+
+import android.app.Application;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.util.Log;
+
+import com.microsoft.applicationinsights.contracts.User;
+import com.microsoft.applicationinsights.library.config.Configuration;
+import com.microsoft.applicationinsights.logging.InternalLogging;
+
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class Module {
+    /**
+     * The tag for logging.
+     */
+    private static final String TAG = "ApplicationInsights";
+
+    /**
+     * A flag which determines, if developer mode (logging) should be enabled.
+     */
+    private static AtomicBoolean DEVELOPER_MODE = new AtomicBoolean(Util.isEmulator() || Util.isDebuggerAttached());
+
+    /**
+     * The configuration of the SDK.
+     */
+    private Configuration configuration;
+
+    /**
+     * A flag, which determines if sending telemetry data should be disabled. Default is false.
+     */
+    private boolean telemetryDisabled;
+
+    /**
+     * A flag, which determines if crash reporting should be disabled. Default is false.
+     */
+    private boolean exceptionTrackingDisabled;
+
+    /**
+     * A flag, which determines if auto page views should be disabled from the start.
+     * Default is false.
+     */
+    private boolean autoPageViewsDisabled;
+
+    /**
+     * A flag, which determines if auto session management should be disabled from the start.
+     * Default is false.
+     */
+    private boolean autoSessionManagementDisabled;
+
+    /**
+     * A flag, which determines if auto appearance should be disabled from the start.
+     * Default is false.
+     */
+    private boolean autoAppearanceDisabled;
+
+    /**
+     * The instrumentation key associated with the app.
+     */
+    private String instrumentationKey;
+
+    /**
+     * The weakContext which contains additional information for the telemetry data sent out.
+     */
+    private TelemetryContext telemetryContext;
+
+    /**
+     * A custom user object for sending telemetry data. Replaces
+     * userId as we allow more configuration of the user object
+     */
+    private User user;
+
+    /**
+     * The weakContext associated with Application Insights.
+     */
+    private WeakReference<Context> weakContext;
+
+    /**
+     * The application needed for auto collecting telemetry data
+     */
+    private WeakReference<Application> weakApplication;
+
+    /**
+     * Properties associated with this telemetryContext.
+     */
+    private Map<String, String> commonProperties = Collections.synchronizedMap(new HashMap<String, String>());
+
+    /**
+     * Flag that indicates that the user has called a setup-method before
+     */
+    private static boolean isConfigured;
+
+    /**
+     * Flag that indicates that the pipeline (Channel, Persistence, etc.) have been setup
+     */
+    private static boolean isSetupAndRunning;
+
+    /**
+     * The type of channel to use for logging
+     */
+    private ChannelType channelType;
+
+
+    private TelemetryClient telemetryClient;
+
+    private ExceptionTracking exceptionTracking;
+
+    private String moduleName;
+
+
+    /**
+     * Configure Application Insights Module
+     * Note: This should be called before start
+     *
+     * @param moduleName  the name of the module, used for system preferences
+     * @param context     the application context associated with Application Insights
+     * @param application the application needed for auto collecting telemetry data
+     */
+    public Module(String moduleName, Context context, Application application) {
+        setup(moduleName, context, application, null);
+    }
+
+    /**
+     * Configure Application Insights
+     * Note: This should be called before start
+     *
+     * @param moduleName         the name of the module, used for system preferences
+     * @param context            the application context associated with Application Insights
+     * @param application        the application needed for auto collecting telemetry data
+     * @param instrumentationKey the instrumentation key associated with the app
+     */
+    public Module(String moduleName, Context context, Application application, String instrumentationKey) {
+        setup(moduleName, context, application, instrumentationKey);
+    }
+
+    /**
+     * Configure Application Insights
+     * Note: This should be called before start
+     *
+     * @param moduleName         the name of the module, used for system preferences
+     * @param context            the application context associated with Application Insights
+     * @param application        the application needed for auto collecting telemetry data
+     * @param instrumentationKey the instrumentation key associated with the app
+     */
+    private void setup(String moduleName, Context context, Application application, String instrumentationKey) {
+        if (!isConfigured) {
+            if (moduleName != null && (moduleName.length()) > 0 && context != null) {
+                this.moduleName = moduleName;
+
+                this.channelType = ChannelType.Default;
+                this.configuration = new Configuration();
+
+                this.weakContext = new WeakReference<Context>(context);
+                this.weakApplication = new WeakReference<Application>(application);
+                isConfigured = true;
+                this.instrumentationKey = instrumentationKey;
+
+                if (this.instrumentationKey == null) {
+                    //TODO: what if multiple modules and no ikey was provided?
+                    this.instrumentationKey = readInstrumentationKey(context, moduleName);
+                }
+
+                if (this.user == null) {
+                    //in case the dev uses deprecated method to set the user's ID
+                    this.user = new User();
+                }
+                TelemetryContext.initialize(context, this.instrumentationKey, this.user);
+                this.telemetryContext = TelemetryContext.getSharedInstance();
+                InternalLogging.info(TAG, "ApplicationInsights has been setup correctly.", null);
+            } else {
+                InternalLogging.warn(TAG, "ApplicationInsights could not be setup correctly " +
+                      "because the given moduleName was null or empty or the weakContext was null");
+            }
+        }
+    }
+
+    /**
+     * Reads the instrumentation key from AndroidManifest.xml if it is available
+     *
+     * @param context the application weakContext to check the manifest from
+     * @return the instrumentation key configured for the application
+     */
+    private String readInstrumentationKey(Context context, String moduleName) {
+        String iKey = "";
+        if (context != null) {
+            try {
+                Bundle bundle = context
+                      .getPackageManager()
+                      .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA)
+                      .metaData;
+                if (bundle != null) {
+                    //TODO: multiple modules?
+                    iKey = bundle.getString("com.microsoft.applicationinsights.instrumentationKey." + moduleName);
+                } else {
+                    logInstrumentationInstructions();
+                }
+            } catch (PackageManager.NameNotFoundException exception) {
+                logInstrumentationInstructions();
+                Log.v(TAG, exception.toString());
+            }
+        }
+
+        return iKey;
+    }
+
+    /* Writes instructions on how to configure the instrumentation key.
+        */
+    private void logInstrumentationInstructions() { //TODO: change log info if multiple modules
+        String instructions = "No instrumentation key found.\n" +
+              "Set the instrumentation key in AndroidManifest.xml";
+        String manifestSnippet = "<meta-data\n" +
+              "android:name=\"com.microsoft.applicationinsights.instrumentationKey\"" +
+              this.moduleName + "\n" + "android:value=\"${AI_INSTRUMENTATION_KEY}\" />";
+        InternalLogging.error("MissingInstrumentationkey", instructions + "\n" + manifestSnippet);
+    }
+
+    /**
+     * Start the module
+     * Note: This should be called after {@link #isConfigured}
+     */
+    public void start() {
+        startInstance();
+    }
+
+    /**
+     * Start the module
+     * Note: This should be called after {@link #isConfigured}
+     */
+    private void startInstance() {
+        if (!isConfigured) {
+            InternalLogging.warn(TAG, "Could not start Application Insights since it has not been " +
+                  "setup correctly.");
+            return;
+        }
+        if (!isSetupAndRunning) {
+            Context context = this.weakContext.get();
+
+            initializePipeline(context);
+            startCrashReporting();//TODO does this work with several modules?
+
+            Sender.getInstance().sendDataOnAppStart();
+            InternalLogging.info(TAG, "ApplicationInsights has been started.", "");
+            isSetupAndRunning = true;
+        }
+    }
+
+    private void startCrashReporting() {
+        // Start crash reporting
+        if (!this.exceptionTrackingDisabled) {
+            ExceptionTracking.registerExceptionHandler();
+        }
+    }
+
+    /**
+     * Makes sure Persistence, Sender, ChannelManager, TelemetryClient and AutoCollection are initialized
+     * Call this before starting AutoCollection
+     *
+     * @param context application context
+     */
+    private void initializePipeline(Context context) {
+        EnvelopeFactory.initialize(telemetryContext, this.commonProperties); //TODO un-singleton EnvelopeFactory
+
+        Persistence.initialize(context); //TODO un-singleton Persistence
+        Sender.initialize(this.configuration); //TODO un-singleton Sender
+        ChannelManager.initialize(channelType); //TODO un-singleton ChannelManager
+
+        // Initialize Telemetry
+        Application application = null;
+        if (this.weakApplication != null) {
+            application = this.weakApplication.get();
+        }
+        TelemetryClient.initialize(!this.telemetryDisabled, application); //TODO unsingleton TelemetryClient
+        TelemetryClient.startAutoCollection(this.telemetryContext, this.configuration, !this.autoAppearanceDisabled, !this.autoPageViewsDisabled, !this.autoSessionManagementDisabled);
+    }
+}

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/TelemetryClient.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/TelemetryClient.java
@@ -3,7 +3,7 @@ package com.microsoft.applicationinsights.library;
 import android.app.Application;
 
 import com.microsoft.applicationinsights.contracts.TelemetryData;
-import com.microsoft.applicationinsights.library.config.ApplicationInsightsConfig;
+import com.microsoft.applicationinsights.library.config.Configuration;
 import com.microsoft.applicationinsights.logging.InternalLogging;
 
 import java.lang.ref.WeakReference;
@@ -23,7 +23,7 @@ public class TelemetryClient {
     /**
      * The configuration of the SDK.
      */
-    private ApplicationInsightsConfig config;
+    private Configuration config;
 
     /**
      * The shared TelemetryClient instance.
@@ -113,7 +113,7 @@ public class TelemetryClient {
     /**
      * Start auto collection features.
      */
-    protected static void startAutoCollection(TelemetryContext context, ApplicationInsightsConfig config, boolean autoAppearanceEnabled, boolean autoPageViewsEnabled, boolean autoSessionManagementEnabled){
+    protected static void startAutoCollection(TelemetryContext context, Configuration config, boolean autoAppearanceEnabled, boolean autoPageViewsEnabled, boolean autoSessionManagementEnabled){
 
         AutoCollection.initialize(context, config);
 

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/config/Configuration.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/config/Configuration.java
@@ -5,7 +5,7 @@ import com.microsoft.applicationinsights.library.ApplicationInsights;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class ApplicationInsightsConfig implements ISenderConfig, ISessionConfig, IQueueConfig {
+public class Configuration implements ISenderConfig, ISessionConfig, IQueueConfig {
 
     // Default values for queue config
     static final int DEBUG_MAX_BATCH_COUNT = 5;
@@ -55,7 +55,7 @@ public class ApplicationInsightsConfig implements ISenderConfig, ISessionConfig,
     /**
      * Constructs a new INSTANCE of a config
      */
-    public ApplicationInsightsConfig() {
+    public Configuration() {
 
 
         // Initialize default values for queue config


### PR DESCRIPTION
@chrwend 
not really intended for merging.
this is my proposal for your question about "where should context/config go" and "what do we do in case of multiple telemetryclients".

See the changelog and the to do's. If you like the idea, continue working on it?
General idea:
- "ModuleName" --> we have a module called "default"
- devs can register new modules with a name and ikey
- important: for each module, we would need an ikey in the AndroidManifest/build-file. My idea would be: the default module can be setup with an ikey in code, manifest or build-file. All additional modules have to provide the ikey in code
