### PR TITLE
Feature/update cll

### DIFF
--- a/applicationinsights-android/build.gradle
+++ b/applicationinsights-android/build.gradle
@@ -113,8 +113,8 @@ if (!this.hasProperty('bintray_user') ||
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile('com.github.microsoft.telemetry-client-for-android:SharedTelemetryContracts:1.0')
-    compile 'com.github.microsoft.telemetry-client-for-android:AndroidCll:1.0'
+    compile'com.github.microsoft.telemetry-client-for-android:SharedTelemetryContracts:2.0.0'
+    compile 'com.github.microsoft.telemetry-client-for-android:AndroidCll:2.0.0'
 
     androidTestCompile 'org.mockito:mockito-core:2.0.17-beta'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'

--- a/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/ChannelManager.java
+++ b/applicationinsights-android/src/main/java/com/microsoft/applicationinsights/library/ChannelManager.java
@@ -1,7 +1,9 @@
 package com.microsoft.applicationinsights.library;
 
 import com.microsoft.applicationinsights.logging.InternalLogging;
-import com.microsoft.cll.Android.AndroidCll;
+
+import com.microsoft.cll.android.AndroidCll;
+
 import com.microsoft.telemetry.IChannel;
 
 /**


### PR DESCRIPTION
Updated the reference to Telemetry-Client-for Android to the latest version which fixes a memory leak and removes the org.json dependency which causes a warning. 
